### PR TITLE
Update NPM token

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,9 +16,7 @@
     {
       "hostType": "npm",
       "matchHost": "registry.npmjs.org",
-      "encrypted": {
-        "token": "SvaO1yukcfZ7M/tyBBfvuTcsNtyQExg1A6ILbcipqChJJgNRXc19NCv3b9USAVdCkyUQzmwrnDDsTXBApgjTXgPgubdONweGPeJTJlqhR6jBe8xxPT8Pu9GIZLYyCJsTLNSnZG0CeCjUIs3fPo0psI+GqbN816+GKO2ufR6v0VeiKNKuvuH+PCG5BPufW8zfepCru+nz9llt+tg+F6C+41HfE/Ec9hTXebKRJpWHYFZ6RM+XeOws25IhozI9HOqO6ILDHjt8qi5ncvCjuSZl8plsz83a1Dda3FPHM58Yqc17BJ9293ZUlafLSclKQC/5YMY1T7FPj8TVI8wnamwZ+Q=="
-      }
+      "token": "{{ secrets.MEND_NPM_REGISTRY_TOKEN }}"
     }
   ],
 


### PR DESCRIPTION
> Config-based secrets encryption is no longer supported by Mend-hosted apps and has been superseded by a UI-based upload of secrets.